### PR TITLE
Modify MPR dashboard widget to read query params

### DIFF
--- a/mpr-summary-dashboard/backend/README.md
+++ b/mpr-summary-dashboard/backend/README.md
@@ -62,6 +62,6 @@ This will create the balx files in engineering-mgt/mpr-summary-dashboard/backend
 - Schedule daily_updater.balx to be executed once a day and pr_status_emailer.balx to be executed weekly.
 - Start the dashboard_services.balx in the background by issuing below in engineering-mgt/mpr-summary-dashboard/backend
 ``` 
-  <Ballerina runtime>/bin/ballerina run daily_updater.balx
+  <Ballerina runtime>/bin/ballerina run dashboard_services.balx
 ```
 - Now the Merged PR dashboard backend is ready to be used. 

--- a/mpr-summary-dashboard/widget/widget-frontend/README.md
+++ b/mpr-summary-dashboard/widget/widget-frontend/README.md
@@ -4,6 +4,13 @@ To install the dependencies required to to build this widget, navigate to the en
 ```
 npm install
 ```
+The engineering-mgt/mpr-summary-dashboard/widget/widget-frontend/src/config.json contains the url for the original Merged PR dashboard, which is deployed using WSO2 Application Server.
+
+```
+{
+    "mprdashboard": "http://<hostname>:<port>/<webapp_name>"
+}
+```
 
 Go to the engineering-mgt/mpr-summary-dashboard/widget/**widget-frontend** directory and issue the following command to build the widget.
 ```

--- a/mpr-summary-dashboard/widget/widget-frontend/src/MPRSummary.jsx
+++ b/mpr-summary-dashboard/widget/widget-frontend/src/MPRSummary.jsx
@@ -373,19 +373,6 @@ class MPRSummary extends Widget {
     }
 
     componentDidMount() {
-        // this.loadProducts();
-
-        // // If the query params contain a product & version they will be used
-        // let alreadySelectedProduct = super.getGlobalState("selectedProduct");
-        // let alreadySelectedVersion = super.getGlobalState("selectedVersion");
-        // if ((!(Object.getOwnPropertyNames(alreadySelectedProduct).length === 0))
-        //     && (!(Object.getOwnPropertyNames(alreadySelectedVersion).length === 0))) {
-        //     this.setState({
-        //         selectedProduct: alreadySelectedProduct,
-        //         selectedVersion: alreadySelectedVersion
-        //     });
-        // }
-
         this.loadProducts();
     }
 


### PR DESCRIPTION
## Purpose
Currently the Merged PR dashboard widget is not able to set query params or read query params. This PR is to add that ability using the [GlobalState](https://github.com/wso2/carbon-dashboards/blob/master/base-widget/src/Widget.jsx) in base widget.

sample url with query params:
```/portal/dashboards/mprdashboard/home#{"product":"IAM","version":"5.7.1"}```