### PR TITLE
Modify README files and rrm config namespace

### DIFF
--- a/checklist-dashboard/widget/widget-backend/README.md
+++ b/checklist-dashboard/widget/widget-backend/README.md
@@ -8,7 +8,7 @@ Add the Ballerina service url to <SP_HOME>/conf/dashboard/deployment.yaml follow
 
 ```
 # RRM dashboards backend URLs
-rrm.configs:
+rrm.checklist.configs:
   checklistBackendUrl: 'http://localhost:9090'
 ```
 

--- a/checklist-dashboard/widget/widget-backend/README.md
+++ b/checklist-dashboard/widget/widget-backend/README.md
@@ -13,7 +13,7 @@ rrm.checklist.configs:
 ```
 
 To build the widget-backend intermediate service run below command from 
-engineering-mgt/mpr-summary-dashboard/widget/**widget-backend**
+engineering-mgt/checklist-dashboard/widget/**widget-backend**
 ```
 mvn clean install
 ```

--- a/checklist-dashboard/widget/widget-backend/src/main/java/org/wso2/checklistservice/beans/RRMConfigurations.java
+++ b/checklist-dashboard/widget/widget-backend/src/main/java/org/wso2/checklistservice/beans/RRMConfigurations.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.config.annotation.Element;
  * Bean class for RRM dashboards
  **/
 
-@Configuration(namespace = "rrm.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
+@Configuration(namespace = "rrm.checklist.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
 public class RRMConfigurations {
 
     /**

--- a/database/datasource-samples/backend-services.yaml
+++ b/database/datasource-samples/backend-services.yaml
@@ -1,3 +1,12 @@
 # RRM dashboards backend URLs
-rrm.configs:
-  mprBackendUrl: 'http://localhost:9090'
+rrm.mpr.configs:
+  mprBackendUrl: "http://localhost:9090"
+
+rrm.gitissue.configs:
+  gitIssueBackendUrl: "http://localhost:9095"
+
+rrm.dependency.configs:
+  dependencyDashboardBackendUrl: "http://localhost:9091"
+
+rrm.checklist.configs:
+  checklistBackendUrl: "http://localhost:6095"

--- a/dependency-dashboard/widget/widget-backend/README.md
+++ b/dependency-dashboard/widget/widget-backend/README.md
@@ -7,7 +7,7 @@ The widget will call the endpoints mentioned in this service and the service is 
 Add the Ballerina service url to <SP_HOME>/conf/dashboard/deployment.yaml
 ```
 # RRM dashboards backend URLs
-rrm.configs:
+rrm.dependency.configs:
   dependencyDashboardBackendUrl: 'http://localhost:9091'
 ```
 

--- a/dependency-dashboard/widget/widget-backend/src/main/java/org/wso2/dependencydashboard/RRMConfigurations.java
+++ b/dependency-dashboard/widget/widget-backend/src/main/java/org/wso2/dependencydashboard/RRMConfigurations.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.config.annotation.Element;
  * Bean class for RRM dashboards
  **/
 
-@Configuration(namespace = "rrm.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
+@Configuration(namespace = "rrm.dependency.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
 public class RRMConfigurations {
 
     /**

--- a/git-issues-monitoring-dashboard/widget/widget-backend/README.md
+++ b/git-issues-monitoring-dashboard/widget/widget-backend/README.md
@@ -9,7 +9,7 @@ Add the Ballerina service url to <SP_HOME>/conf/dashboard/deployment.yaml follow
 ```
 # RRM dashboards backend URLs
 rrm.gitissue.configs:
-  mprBackendUrl: 'http://localhost:9090'
+  gitIssueBackendUrl: 'http://localhost:9090'
 ```
 
 To build the widget-backend intermediate service run below command from 

--- a/git-issues-monitoring-dashboard/widget/widget-backend/README.md
+++ b/git-issues-monitoring-dashboard/widget/widget-backend/README.md
@@ -1,0 +1,20 @@
+# git-issues-monitoring-widget-backend
+
+This is to generate an intermediate service which will act as the backend of the Git Issues Monitoring dashboard widgets. 
+
+The widget will call the endpoints mentioned in this service and the service is responsible for invoking appropriate endpoints from the Ballerina service.
+
+Add the Ballerina service url to <SP_HOME>/conf/dashboard/deployment.yaml following the sample in engineering-mgt/database/datasource-samples/**backend-services.yaml**
+
+```
+# RRM dashboards backend URLs
+rrm.gitissue.configs:
+  mprBackendUrl: 'http://localhost:9090'
+```
+
+To build the widget-backend intermediate service run below command from 
+engineering-mgt/mpr-summary-dashboard/widget/**widget-backend**
+```
+mvn clean install
+```
+Place the resulted target/mpr-backend-service.jar in <SP_HOME>/libs

--- a/git-issues-monitoring-dashboard/widget/widget-backend/README.md
+++ b/git-issues-monitoring-dashboard/widget/widget-backend/README.md
@@ -13,8 +13,8 @@ rrm.gitissue.configs:
 ```
 
 To build the widget-backend intermediate service run below command from 
-engineering-mgt/mpr-summary-dashboard/widget/**widget-backend**
+engineering-mgt/git-issues-monitoring-dashboard/widget/**widget-backend**
 ```
 mvn clean install
 ```
-Place the resulted target/mpr-backend-service.jar in <SP_HOME>/libs
+Place the resulted target/git-issue-service.jar in <SP_HOME>/libs

--- a/git-issues-monitoring-dashboard/widget/widget-backend/src/main/java/org/wso2/git/issue/service/internal/RRMConfigurations.java
+++ b/git-issues-monitoring-dashboard/widget/widget-backend/src/main/java/org/wso2/git/issue/service/internal/RRMConfigurations.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.config.annotation.Element;
  * Bean class for RRM dashboards
  **/
 
-@Configuration(namespace = "rrm.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
+@Configuration(namespace = "rrm.gitissue.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
 public class RRMConfigurations {
 
     /**

--- a/mpr-summary-dashboard/widget/widget-backend/README.md
+++ b/mpr-summary-dashboard/widget/widget-backend/README.md
@@ -8,7 +8,7 @@ Add the Ballerina service url to <SP_HOME>/conf/dashboard/deployment.yaml follow
 
 ```
 # RRM dashboards backend URLs
-rrm.configs:
+rrm.mpr.configs:
   mprBackendUrl: 'http://localhost:9090'
 ```
 

--- a/mpr-summary-dashboard/widget/widget-backend/src/main/java/org/wso2/mprservice/beans/RRMConfigurations.java
+++ b/mpr-summary-dashboard/widget/widget-backend/src/main/java/org/wso2/mprservice/beans/RRMConfigurations.java
@@ -27,7 +27,7 @@ import org.wso2.carbon.config.annotation.Element;
  * Bean class for RRM dashboards
  **/
 
-@Configuration(namespace = "rrm.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
+@Configuration(namespace = "rrm.mpr.configs", description = "WSO2 Release Readiness Matrices Dashboard Configs")
 public class RRMConfigurations {
 
     /**


### PR DESCRIPTION
This PR is to add/modify widget-backend README files and to modify the namespace in rrm configs.

The backend urls for RRM dashboards in SP_HOME/conf/dashboard/deployment.yaml should look like this:

```
# RRM dashboards backend URLs
rrm.mpr.configs:
  mprBackendUrl: "http://localhost:9090"

rrm.gitissue.configs:
  gitIssueBackendUrl: "http://localhost:9095"

rrm.dependency.configs:
  dependencyDashboardBackendUrl: "http://localhost:9091"

rrm.checklist.configs:
  checklistBackendUrl: "http://localhost:6095"

```
