### PR TITLE
Fix widget not loading error due to missing jacoco resources

### DIFF
--- a/code-coverage-dashboard/widget/widget-backend/src/main/java/org/wso2/codecoverageservice/CoverageServiceProvider.java
+++ b/code-coverage-dashboard/widget/widget-backend/src/main/java/org/wso2/codecoverageservice/CoverageServiceProvider.java
@@ -139,24 +139,33 @@ class CoverageServiceProvider {
                 ps.setString(2,  date + "%");
                 ResultSet summaryResult = ps.executeQuery();
 
+                String sumDate = "";
+                String sumBuilds = "Error in the last build. Contact admin.";
+                DaySummary daySummary = new DaySummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
                 while (summaryResult.next()) {
-                    DaySummary daySummary = new DaySummary(summaryResult.getInt("total_instructions"),
-                                                           summaryResult.getInt("missed_instructions"),
-                                                           summaryResult.getInt("total_branches"),
-                                                           summaryResult.getInt("missed_branches"),
-                                                           summaryResult.getInt("total_cxty"),
-                                                           summaryResult.getInt("missed_cxty"),
-                                                           summaryResult.getInt("total_lines"),
-                                                           summaryResult.getInt("missed_lines"),
-                                                           summaryResult.getInt("total_methods"),
-                                                           summaryResult.getInt("missed_methods"),
-                                                           summaryResult.getInt("total_classes"),
-                                                           summaryResult.getInt("missed_classes"));
-                    productObj.add("data", new Gson().toJsonTree(daySummary));
-                    productObj.addProperty("date", summaryResult.getString("date"));
-                    productObj.addProperty("build_no", summaryResult.getString("builds"));
+                    sumDate = summaryResult.getString("date");
+                    sumBuilds = summaryResult.getString("builds");
+
+                    daySummary.setTotalIns(summaryResult.getInt("total_instructions"));
+                    daySummary.setMissIns(summaryResult.getInt("missed_instructions"));
+                    daySummary.setTotalBranches(summaryResult.getInt("total_branches"));
+                    daySummary.setMissBranches(summaryResult.getInt("missed_branches"));
+                    daySummary.setTotalCxty(summaryResult.getInt("total_cxty"));
+                    daySummary.setMissCxty(summaryResult.getInt("missed_cxty"));
+                    daySummary.setTotalLines(summaryResult.getInt("total_lines"));
+                    daySummary.setMissLines(summaryResult.getInt("missed_lines"));
+                    daySummary.setTotalMethods(summaryResult.getInt("total_methods"));
+                    daySummary.setMissMethods(summaryResult.getInt("missed_methods"));
+                    daySummary.setTotalClasses(summaryResult.getInt("total_classes"));
+                    daySummary.setMissClasses(summaryResult.getInt("missed_classes"));
+
                 }
+                productObj.add("data", new Gson().toJsonTree(daySummary));
+                productObj.addProperty("date", sumDate);
+                productObj.addProperty("build_no", sumBuilds);
                 productObj.addProperty("name", productsResult.getString("product_name"));
+
                 coverageSummary.add(productObj);
             }
         } catch (SQLException e) {

--- a/code-coverage-dashboard/widget/widget-backend/src/main/java/org/wso2/codecoverageservice/beans/DaySummary.java
+++ b/code-coverage-dashboard/widget/widget-backend/src/main/java/org/wso2/codecoverageservice/beans/DaySummary.java
@@ -37,7 +37,7 @@ public class DaySummary {
         return totalIns;
     }
 
-    private void setTotalIns(int totalIns) {
+    public void setTotalIns(int totalIns) {
         this.totalIns = totalIns;
     }
 
@@ -45,7 +45,7 @@ public class DaySummary {
         return missIns;
     }
 
-    private void setMissIns(int missIns) {
+    public void setMissIns(int missIns) {
         this.missIns = missIns;
     }
 
@@ -53,7 +53,7 @@ public class DaySummary {
         return totalBranches;
     }
 
-    private void setTotalBranches(int totalBranches) {
+    public void setTotalBranches(int totalBranches) {
         this.totalBranches = totalBranches;
     }
 
@@ -61,7 +61,7 @@ public class DaySummary {
         return missBranches;
     }
 
-    private void setMissBranches(int missBranches) {
+    public void setMissBranches(int missBranches) {
         this.missBranches = missBranches;
     }
 
@@ -69,7 +69,7 @@ public class DaySummary {
         return totalCxty;
     }
 
-    private void setTotalCxty(int totalCxty) {
+    public void setTotalCxty(int totalCxty) {
         this.totalCxty = totalCxty;
     }
 
@@ -77,7 +77,7 @@ public class DaySummary {
         return missCxty;
     }
 
-    private void setMissCxty(int missCxty) {
+    public void setMissCxty(int missCxty) {
         this.missCxty = missCxty;
     }
 
@@ -85,7 +85,7 @@ public class DaySummary {
         return totalLines;
     }
 
-    private void setTotalLines(int totalLines) {
+    public void setTotalLines(int totalLines) {
         this.totalLines = totalLines;
     }
 
@@ -93,7 +93,7 @@ public class DaySummary {
         return missLines;
     }
 
-    private void setMissLines(int missLines) {
+    public void setMissLines(int missLines) {
         this.missLines = missLines;
     }
 
@@ -101,7 +101,7 @@ public class DaySummary {
         return totalMethods;
     }
 
-    private void setTotalMethods(int totalMethods) {
+    public void setTotalMethods(int totalMethods) {
         this.totalMethods = totalMethods;
     }
 
@@ -109,7 +109,7 @@ public class DaySummary {
         return missMethods;
     }
 
-    private void setMissMethods(int missMethods) {
+    public void setMissMethods(int missMethods) {
         this.missMethods = missMethods;
     }
 
@@ -117,7 +117,7 @@ public class DaySummary {
         return totalClasses;
     }
 
-    private void setTotalClasses(int totalClasses) {
+    public void setTotalClasses(int totalClasses) {
         this.totalClasses = totalClasses;
     }
 
@@ -125,7 +125,7 @@ public class DaySummary {
         return missClasses;
     }
 
-    private void setMissClasses(int missClasses) {
+    public void setMissClasses(int missClasses) {
         this.missClasses = missClasses;
     }
 

--- a/code-coverage-dashboard/widget/widget-frontend/table-widget/src/CodeCoverageTable.jsx
+++ b/code-coverage-dashboard/widget/widget-frontend/table-widget/src/CodeCoverageTable.jsx
@@ -130,7 +130,11 @@ const TableDiv = {
 // methods
 // get code coverage percentage
 export function getPercentage(total, miss) {
-    return (((total - miss) / total) * 100).toFixed(2)
+    if(total > 0) {
+        return (((total - miss) / total) * 100).toFixed(2)
+    } else {
+        return 0;
+    }
 }
 
 // get date as a string (yyyy-mm-dd)


### PR DESCRIPTION
## Purpose
> When some repo build does not contain jacoco resources zip for a particular build, When the user selects the date which relevant build has triggered, the widget will not load due to some error. This happened because summary data is missing for the relevant product. Fixing this issue in this PR.

Fixes; https://github.com/wso2/engineering-mgt/issues/16